### PR TITLE
Add CertCreator

### DIFF
--- a/tls/cert_creator.go
+++ b/tls/cert_creator.go
@@ -1,0 +1,244 @@
+// Portions Copyright 2009 The Go Authors. All rights reserved. Use of this
+// source code is governed by a BSD-style license that can be found in the
+// LICENSE file.
+//
+// Portions Copyright 2014 Fastly, Inc.
+
+package tls
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"net"
+	"os"
+	"time"
+
+	"github.com/fastly/go-utils/vlog"
+)
+
+// CertCreator generates client or server public/private RSA keypairs signed by
+// a generated self-signed certificate authority (CA). It will reload the CA
+// cert from disk if present, and will not overwrite a keypair if either the
+// key or cert exists on disk, so a cert generation program can be safely
+// re-run after adding new certs. All keys are granted the minimal set of
+// extended key usages for their purpose.
+//
+// The default values described below are not for the zero value, but rather
+// those returned by NewCertCreator().
+//
+// Example:
+//
+//	cc := tls.NewCertCreator()
+//	root := cc.GenerateRootKeyPair("my-ca", "My CA")
+//	host := "*.mydomain.com"
+//	cc.GenerateKeyPair(CLIENT, root, "proxy-client", host, host)
+//	cc.GenerateKeyPair(SERVER, root, "proxy-server", host, host)
+type CertCreator struct {
+	// Serial number, defaults to 1.
+	Serial int64
+	// Time period in which the cert if valid, defaults to the current time
+	// until the maximum of 2049-12-13.
+	NotBefore, NotAfter time.Time
+	// Key size in bytes, defaults to 4096.
+	KeySize int
+	// Descriptive names for the organization creating the CA. Defaults to
+	// empty.
+	Country, State, City, Organization string
+}
+
+// NewCertCreator returns a CertCreator with default values.
+func NewCertCreator() *CertCreator {
+	return &CertCreator{
+		Serial:    1,
+		NotBefore: time.Now(),
+		NotAfter:  time.Date(2049, 12, 31, 23, 59, 59, 0, time.UTC), // end of ASN.1 time
+		KeySize:   4096,
+	}
+}
+
+type Purpose int
+
+const (
+	// CA certs are used only for signing other certs.
+	CA Purpose = iota
+	// CLIENT certs are presented by clients which initiate TLS connections.
+	CLIENT
+	// SERVER certs are presented by servers which accept TLS connections.
+	SERVER
+)
+
+type KeyPair struct {
+	Cert    *x509.Certificate
+	PrivKey *rsa.PrivateKey
+}
+
+// GenerateRootKeyPair creates or reloads a self-signed CA cert.
+func (cc *CertCreator) GenerateRootKeyPair(name string, commonName string, hosts ...string) (*KeyPair, error) {
+	return cc.GenerateKeyPair(CA, nil, name, commonName, hosts...)
+}
+
+// GenerateKeyPair generates or reloads an RSA keypair with key usages
+// determined by `purpose`. The disk files that are generated or reused are
+// named `name`-key.pem and `name`-cert.pem for the private and public halves,
+// respectively. `commonName` and `hosts` are the corresponding fields in the
+// certificate.
+//
+// cc.Serial is incremented for each key that is freshly generated.
+func (cc *CertCreator) GenerateKeyPair(purpose Purpose, parent *KeyPair, name string, commonName string, hosts ...string) (*KeyPair, error) {
+	if pair, err := LoadKeyPairFromDisk(name); err == nil {
+		return pair, nil
+	}
+
+	keyFile, certFile := name+"-key.pem", name+"-cert.pem"
+	if _, err := os.Open(keyFile); !os.IsNotExist(err) {
+		return nil, fmt.Errorf("Key file %q already exists", keyFile)
+	}
+	if _, err := os.Open(certFile); !os.IsNotExist(err) {
+		return nil, fmt.Errorf("Cert file %q already exists", keyFile)
+	}
+
+	var extUsages []x509.ExtKeyUsage
+	if purpose == CA {
+		extUsages = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}
+	} else if purpose == SERVER {
+		extUsages = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+	} else {
+		extUsages = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	}
+
+	serial := new(big.Int).SetInt64(cc.Serial)
+	cc.Serial++
+	template := x509.Certificate{
+		Subject: pkix.Name{
+			Country:      []string{cc.Country},
+			Province:     []string{cc.State},
+			Locality:     []string{cc.City},
+			Organization: []string{cc.Organization},
+			CommonName:   commonName,
+			SerialNumber: serial.String(),
+		},
+
+		NotBefore:    cc.NotBefore,
+		NotAfter:     cc.NotAfter,
+		SerialNumber: serial,
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           extUsages,
+		BasicConstraintsValid: true, // enforces IsCA and KeyUsage
+	}
+	if purpose == CA {
+		template.IsCA = true
+		template.KeyUsage = x509.KeyUsageCertSign
+	} else {
+		template.MaxPathLen = 1
+	}
+
+	// generate IP and DNS SANs
+	for _, h := range hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else {
+			template.DNSNames = append(template.DNSNames, h)
+		}
+	}
+
+	if parent == nil {
+		privkey, err := rsa.GenerateKey(rand.Reader, cc.KeySize)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to generate private key: %s", err)
+		}
+		parent = &KeyPair{&template, privkey}
+	}
+
+	// sign the key
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, parent.Cert, &parent.PrivKey.PublicKey, parent.PrivKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// check that the cert verifies against its own CA
+	cert, err := x509.ParseCertificate(derBytes)
+	if err != nil {
+		return nil, fmt.Errorf("Cert doesn't veryfiy against its CA: %s", err)
+	}
+
+	roots := x509.NewCertPool()
+	if purpose == CA {
+		roots.AddCert(cert)
+	} else {
+		roots.AddCert(parent.Cert)
+	}
+	_, err = cert.Verify(x509.VerifyOptions{Roots: roots, KeyUsages: extUsages})
+	if err != nil {
+		return nil, fmt.Errorf("Couldn't verify %q against its own CA: %s", name, err)
+	}
+
+	// write key and cert to disk
+	keyOut, err := os.OpenFile(keyFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to open %q for writing: %s", keyFile, err)
+	}
+	pem.Encode(keyOut, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(parent.PrivKey)})
+	keyOut.Close()
+	vlog.VLogf("Wrote key %q\n", keyFile)
+
+	certOut, err := os.Create(certFile)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to open %q for writing: %s", certFile, err)
+	}
+	pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	certOut.Close()
+	vlog.VLogf("Wrote cert %q\n", certFile)
+
+	return LoadKeyPairFromDisk(name)
+}
+
+// LoadKeyPairFromDisk returns a KeyPair from disk files based on the given
+// name.
+func LoadKeyPairFromDisk(name string) (*KeyPair, error) {
+	// cert
+	certFile := name + "-cert.pem"
+	b, err := ioutil.ReadFile(certFile)
+	if err != nil {
+		return nil, err
+	}
+
+	block, _ := pem.Decode(b)
+	if block == nil {
+		return nil, fmt.Errorf("No PEM data found in %q", certFile)
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	vlog.VLogf("Loaded cert from %s", certFile)
+
+	// private key
+	keyFile := name + "-key.pem"
+	b, err = ioutil.ReadFile(keyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	block, _ = pem.Decode(b)
+	if block == nil {
+		return nil, fmt.Errorf("No PEM data found in %q", keyFile)
+	}
+
+	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	vlog.VLogf("Loaded key from %s", keyFile)
+
+	return &KeyPair{cert, key}, nil
+}

--- a/tls/cert_creator_test.go
+++ b/tls/cert_creator_test.go
@@ -1,0 +1,280 @@
+package tls_test
+
+import (
+	gotls "crypto/tls"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fastly/go-utils/tls"
+)
+
+func init() {
+	log.SetFlags(log.Lmicroseconds)
+}
+
+// test that CertCreator makes client/server certs that 1) work when used
+// correctly and 2) don't work when used with different CAs
+func TestCertCreator(t *testing.T) {
+	cc := tls.NewCertCreator()
+	cc.KeySize = 512
+	cc.Country = "US"
+	cc.State = "CA"
+	cc.City = "San Francisco"
+	cc.Organization = "Fastly Testing"
+
+	var wg sync.WaitGroup
+	done := false
+
+	type group struct {
+		name         string
+		clientConfig *gotls.Config
+		serverConfig *gotls.Config
+		listener     net.Listener
+		errors       chan error
+		cleanup      func()
+	}
+
+	// generate ca, client, and server keypairs with the given name, and stand
+	// up a TLS listener
+	setup := func(name string) (g *group, err error) {
+		g = &group{
+			name:   name,
+			errors: make(chan error),
+			cleanup: func() {
+				for _, f := range []string{
+					"-ca-key.pem",
+					"-ca-cert.pem",
+					"client-key.pem",
+					"client-cert.pem",
+					"server-key.pem",
+					"server-cert.pem",
+				} {
+					file := "testcerts/" + name + f
+					if err := os.Remove(file); err != nil {
+						t.Errorf("couldn't remove %q: %s", err)
+					}
+				}
+			},
+		}
+
+		// put certs in testcerts/ since LocatePackagedPEMDir looks there
+		root, err := cc.GenerateRootKeyPair("testcerts/"+name+"-ca", name+" CA")
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		host := "0.0.0.0"
+
+		_, err = cc.GenerateKeyPair(tls.CLIENT, root, "testcerts/"+name+"client", host, host)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		_, err = cc.GenerateKeyPair(tls.SERVER, root, "testcerts/"+name+"server", host, host)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		g.clientConfig, err = tls.ConfigureClient(name+"client", name+"-ca")
+		if err != nil {
+			t.Errorf("%s client: %s", name+"client", err)
+			return
+		}
+
+		g.serverConfig, err = tls.ConfigureServer(name+"server", name+"-ca")
+		if err != nil {
+			t.Errorf("%s server: %s", name+"server", err)
+			return
+		}
+
+		listener, err := gotls.Listen("tcp4", host+":0", g.serverConfig)
+		if err != nil {
+			t.Errorf("%s listen: %s", name, err)
+			return
+		}
+		g.listener = listener
+		g.clientConfig.ServerName = g.listener.Addr().(*net.TCPAddr).IP.String() // required for client to validate server cert
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				conn, err := listener.Accept()
+				if done {
+					return
+				}
+				if err != nil {
+					g.errors <- err
+					return
+				}
+				if conn == nil {
+					g.errors <- fmt.Errorf("no conn or err")
+					return
+				}
+				wg.Add(1)
+				go func(conn net.Conn) {
+					defer wg.Done()
+					defer conn.Close()
+
+					conn.SetDeadline(time.Now().Add(time.Second))
+					err = conn.(*gotls.Conn).Handshake()
+					if err != nil {
+						g.errors <- err
+						return
+					}
+
+					conn.SetDeadline(time.Now().Add(time.Second))
+					b := make([]byte, 3) // len("foo")
+					n, err := conn.Read(b)
+					b = b[:n]
+					if err != nil {
+						g.errors <- err
+						return
+					}
+					if string(b) != "foo" {
+						g.errors <- fmt.Errorf("%q != %q", b, "foo")
+						return
+					}
+					conn.SetDeadline(time.Now().Add(time.Second))
+					n, err = io.WriteString(conn, "bar")
+					if err != nil {
+						g.errors <- err
+						return
+					}
+					g.errors <- nil
+				}(conn)
+			}
+		}()
+		return
+	}
+
+	// try to create a TLS connection from client to server and send a bit of
+	// data back and forth
+	check := func(client, server *group, expectedClientError, expectedServerError string) {
+		addr := server.listener.Addr().String()
+		conn, err := net.DialTimeout("tcp4", addr, time.Second)
+		if err != nil {
+			t.Errorf("%s->%s: dial: %s", client.name, server.name, err)
+			return
+		}
+
+		tlsConn := gotls.Client(conn, client.clientConfig)
+		clientErr := tlsConn.Handshake()
+		if clientErr == nil {
+			tlsConn.SetDeadline(time.Now().Add(time.Second))
+			if _, err := io.WriteString(tlsConn, "foo"); err == nil {
+				tlsConn.SetDeadline(time.Now().Add(time.Second))
+				b := make([]byte, 3) // len("bar")
+				n, err := tlsConn.Read(b)
+				b = b[:n]
+				if err != nil {
+					clientErr = err
+				}
+				if string(b) != "bar" {
+					clientErr = fmt.Errorf("%q != %q", b, "bar")
+				}
+			} else {
+				clientErr = err
+			}
+			tlsConn.Close()
+		}
+
+		var serverErr error
+		select {
+		case serverErr = <-server.errors:
+		case <-time.After(time.Second):
+			t.Errorf("timed out on serverErr")
+			return
+		}
+
+		if expectedClientError == "" && clientErr != nil {
+			t.Errorf("%s->%s client: should've worked but saw err=`%s`", client.name, server.name, clientErr)
+		}
+		if expectedClientError != "" {
+			if clientErr == nil {
+				t.Errorf("%s->%s client: should not have worked", client.name, server.name)
+			} else if clientErr.Error() != expectedClientError {
+				t.Errorf("%s->%s client: expected error %q but got %q", client.name, server.name, expectedClientError, clientErr)
+			}
+		}
+		if expectedServerError == "" && serverErr != nil {
+			t.Errorf("%s->%s server: should've worked but saw err=`%s`", client.name, server.name, serverErr)
+		}
+		if expectedServerError != "" {
+			if serverErr == nil {
+				t.Errorf("%s->%s server: should not have worked", client.name, server.name)
+			} else if serverErr.Error() != expectedServerError {
+				t.Errorf("%s->%s server: expected error %q but got %q", client.name, server.name, expectedServerError, serverErr)
+			}
+		}
+	}
+
+	// test that friend client talks to friend server, but friend client does
+	// not talk to foe server or foe client to friend server
+	friend, err := setup("friend")
+	if err != nil {
+		t.Errorf("setup: %s", err)
+		return
+	}
+	defer friend.cleanup()
+
+	foe, err := setup("foe")
+	if err != nil {
+		t.Errorf("setup: %s", err)
+		return
+	}
+	defer foe.cleanup()
+
+	// friend to friend: should work
+	check(friend, friend, "", "")
+
+	// friend to foe: friend client should reject foe server
+	check(friend, foe, "x509: certificate signed by unknown authority", "remote error: bad certificate")
+
+	// foe to friend: foe client accepts friend server but server should reject
+	// foe client.
+
+	// prevent client from rejecting the server's "bad" cert so we can test
+	// that the server rejects the client's bad cert.
+	foe.clientConfig.InsecureSkipVerify = true
+
+	// this expects no certificate from the client because
+	// tls/handshake_server.go sends a list of acceptable CA certs to the
+	// client when requesting a client cert and tls/handshake_client.go avoids
+	// sending any cert if no eligible one is in its Config.Certificates.
+	//
+	// a more complete test would be to force the client to send a cert it
+	// knows is bad, but that's a hassle in a pure test so I verified it
+	// manually with a Go 1.2.1 patched to not send the list of CAs from the
+	// server and got:
+	/*
+		--- FAIL: TestCertCreator (0.20 seconds)
+	        cert_creator_test.go:224: foe->friend server: expected error "tls: client didn't provide a certificate" but got "tls: failed to verify client's certificate: x509: certificate signed by unknown authority"
+	*/
+	check(foe, friend, "remote error: bad certificate", "tls: client didn't provide a certificate")
+	foe.clientConfig.InsecureSkipVerify = false
+
+	done = true
+	friend.listener.Close()
+	foe.listener.Close()
+
+	c := make(chan struct{})
+	go func() {
+		wg.Wait()
+		c <- struct{}{}
+	}()
+
+	select {
+	case <-c:
+	case <-time.After(time.Second):
+		t.Errorf("timed out on wg.Wait")
+	}
+}


### PR DESCRIPTION
CertCreator generates client or server public/private RSA keypairs signed by
a generated self-signed certificate authority (CA). It will reload the CA
cert from disk if present, and will not overwrite a keypair if either the
key or cert exists on disk, so a cert generation program can be safely
re-run after adding new certs. All keys are granted the minimal set of
extended key usages for their purpose.
