### PR TITLE
Fix API break

### DIFF
--- a/lifecycle/lifecycle.go
+++ b/lifecycle/lifecycle.go
@@ -142,3 +142,7 @@ func InstallStackTracer() stopper.Stopper {
 	}()
 	return stopper
 }
+
+func GetStackTrace(all bool) string {
+	return instrumentation.GetStackTrace(all)
+}


### PR DESCRIPTION
ce71714 moved GetStackTrace to package instrumentation, but existing
clients expect lifecycle to have it. This forwards to the new location.
