### PR TITLE
Implement BinaryDuplicateProcessIDs on darwin

### DIFF
--- a/executable/executable.go
+++ b/executable/executable.go
@@ -3,7 +3,9 @@
 package executable
 
 import (
+	"fmt"
 	"log"
+	"os"
 	"path/filepath"
 	"syscall"
 
@@ -40,4 +42,31 @@ func Dir() (dir string, err error) {
 	}
 	dir, _ = filepath.Split(path)
 	return
+}
+
+// FindDuplicateProcess looks for any other processes with the same
+// binary name as passed in and returns the first one found.
+func FindDuplicateProcess(binary string) (*os.Process, int, error) {
+	all, err := BinaryDuplicateProcessIDs(binary)
+	if err != nil {
+		return nil, 0, err
+	}
+	if len(all) > 0 {
+		p, err := os.FindProcess(all[0])
+		if err != nil {
+			return nil, 0, err
+		}
+		return p, all[0], nil
+	}
+	return nil, 0, nil
+}
+
+// DuplicateProcessIDs returns all pids belonging to processes with the
+// same binary name as the running program.
+func DuplicateProcessIDs() (pids []int, err error) {
+	binary, err := Path()
+	if err != nil {
+		return nil, fmt.Errorf("Can't get path: %v", err)
+	}
+	return BinaryDuplicateProcessIDs(binary)
 }

--- a/executable/executable_linux.go
+++ b/executable/executable_linux.go
@@ -15,23 +15,6 @@ func Path() (string, error) {
 	return os.Readlink("/proc/self/exe")
 }
 
-// FindDuplicateProcess looks for any other processes with the same
-// binary name as passed in and returns the first one found.
-func FindDuplicateProcess(binary string) (*os.Process, int, error) {
-	all, err := BinaryDuplicateProcessIDs(binary)
-	if err != nil {
-		return nil, 0, err
-	}
-	if len(all) > 0 {
-		p, err := os.FindProcess(all[0])
-		if err != nil {
-			return nil, 0, err
-		}
-		return p, all[0], nil
-	}
-	return nil, 0, nil
-}
-
 // BinaryDuplicateProcessIDs returns all pids belonging to processes with
 // the same passed binary name.
 func BinaryDuplicateProcessIDs(binary string) (pids []int, err error) {
@@ -55,14 +38,4 @@ func BinaryDuplicateProcessIDs(binary string) (pids []int, err error) {
 		}
 	}
 	return pids, nil
-}
-
-// DuplicateProcessIDs returns all pids belonging to processes with the
-// same binary name as the running program.
-func DuplicateProcessIDs() (pids []int, err error) {
-	binary, err := Path()
-	if err != nil {
-		return nil, fmt.Errorf("Can't get path: %v", err)
-	}
-	return BinaryDuplicateProcessIDs(binary)
 }


### PR DESCRIPTION
- Implement BinaryDuplicateProcessIDs using libproc API available in Mac
  OS 10.5+.
- Fix Path() on darwin to return a non-null-terminated Go string.
- Move non-platform-specific funcs FindDuplicateProcess and
  DuplicateProcessIDs from executable_linux.go to executable.go.
