### PR TITLE
Fork /set.id/ syscalls for Go 1.4 support

### DIFF
--- a/privsep/privsep_darwin.go
+++ b/privsep/privsep_darwin.go
@@ -1,0 +1,11 @@
+package privsep
+
+import "syscall"
+
+func setuid(uid int) error {
+	return syscall.Setuid(uid)
+}
+
+func setgid(gid int) error {
+	return syscall.Setgid(gid)
+}

--- a/privsep/privsep_linux.go
+++ b/privsep/privsep_linux.go
@@ -1,12 +1,12 @@
-package internal
+package privsep
 
 // This is a copy of the code removed by
 // https://code.google.com/p/go/source/detail?r=ae0d51eadf44. It is regrettably
-// required to use the privsep package as of Go 1.4.
+// required to use the privsep package on Linux as of Go 1.4.
 
 import "syscall"
 
-func Setuid(uid int) (err error) {
+func setuid(uid int) (err error) {
 	_, _, e1 := syscall.RawSyscall(syscall.SYS_SETUID, uintptr(uid), 0, 0)
 	if e1 != 0 {
 		err = e1
@@ -14,7 +14,7 @@ func Setuid(uid int) (err error) {
 	return
 }
 
-func Setgid(gid int) (err error) {
+func setgid(gid int) (err error) {
 	_, _, e1 := syscall.RawSyscall(syscall.SYS_SETGID, uintptr(gid), 0, 0)
 	if e1 != 0 {
 		err = e1

--- a/privsep/privsep_unix.go
+++ b/privsep/privsep_unix.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux darwin
 
 package privsep
 
@@ -14,7 +14,6 @@ import (
 	"syscall"
 
 	"github.com/fastly/go-utils/executable"
-	"github.com/fastly/go-utils/privsep/internal"
 )
 
 const (
@@ -164,10 +163,10 @@ func dropPrivs() error {
 	}
 
 	// change gid first since it can't be changed after dropping root uid
-	if err := internal.Setgid(gid); err != nil {
+	if err := setgid(gid); err != nil {
 		return err
 	}
-	if err := internal.Setuid(uid); err != nil {
+	if err := setuid(uid); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
https://code.google.com/p/go/source/detail?r=ae0d51eadf44 broke support for the
syscall.Setuid and syscall.Setgid functions that this package relies on.

Go 1.4 before this change:

```
> sudo ./privsep.test -test.v
=== RUN TestPrivsep
--- FAIL: TestPrivsep (120.01s)
    privsep_test.go:60: expected "pong\n", got "operation not supported\n"
    privsep_test.go:69: expected "foo\n", got ""
    privsep_test.go:82: child exited with status 2
FAIL
```

After this change:

```
> sudo ./privsep.test -test.v
=== RUN TestPrivsep
--- PASS: TestPrivsep (0.00s)
    privsep_test.go:58: got expected reply "pong\n"
    privsep_test.go:67: got expected reply "foo\n"
    privsep_test.go:82: child exited with status -1
PASS
```

Untested with respect to darwin support.
