### PR TITLE
Support creating intermediate certs

### DIFF
--- a/tls/cert_creator.go
+++ b/tls/cert_creator.go
@@ -173,6 +173,7 @@ func (cc *CertCreator) GenerateKeyPair(purpose Purpose, parent *KeyPair, name st
 		return nil, err
 	}
 
+	origParent := parent
 	if parent == nil {
 		// CA signs itself
 		parent = &KeyPair{&template, privKey}
@@ -192,7 +193,7 @@ func (cc *CertCreator) GenerateKeyPair(purpose Purpose, parent *KeyPair, name st
 
 	// check that the cert verifies against its own CA
 	roots := x509.NewCertPool()
-	if purpose == CA {
+	if origParent == nil {
 		roots.AddCert(cert)
 	} else {
 		roots.AddCert(parent.Cert)


### PR DESCRIPTION
Previously the signing cert was presumed to be itself if the purpose was
creating a CA keypair; this is not true in the case of an intermediate
CA.

The new test fails with the old code and now passes.