### PR TITLE
Return child errors to callers of CreateChild

### DIFF
--- a/privsep/privsep_test.go
+++ b/privsep/privsep_test.go
@@ -29,6 +29,8 @@ func TestPrivsep(t *testing.T) {
 	}
 
 	if os.Getuid() != 0 {
+		// `sudo go test` doesn't work because it writes the test binary to
+		// /tmp as root with 700 permissions
 		t.Skip("test must run as root: go test -c github.com/fastly/go-utils/privsep && sudo ./privsep.test -test.v")
 	}
 


### PR DESCRIPTION
Previously errors that occurred in the privsep child were written to the
childOut file descriptor and left to the user to sort out. This creates
a separate status pipe so errors can be noticed in the parent and
returned as an error from CreateChild.

Also add a specific error for the case where the running binary is not
executable by the unprivileged user.

On that note, add a comment for why `sudo go test` doesn't work.