### PR TITLE
Use SHA256 for cert signing

### DIFF
--- a/tls/cert_creator.go
+++ b/tls/cert_creator.go
@@ -113,6 +113,8 @@ func (cc *CertCreator) GenerateKeyPair(purpose Purpose, parent *KeyPair, name st
 	serial := new(big.Int).SetInt64(cc.Serial)
 	cc.Serial++
 	template := x509.Certificate{
+		SignatureAlgorithm: x509.SHA256WithRSA,
+
 		Subject: pkix.Name{
 			Country:      []string{cc.Country},
 			Province:     []string{cc.State},

--- a/tls/cert_creator_test.go
+++ b/tls/cert_creator_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	gotls "crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"log"
@@ -170,6 +171,14 @@ func TestCertCreator(t *testing.T) {
 		tlsConn := gotls.Client(conn, client.clientConfig)
 		clientErr := tlsConn.Handshake()
 		if clientErr == nil {
+
+			state := tlsConn.ConnectionState()
+			wantAlgo := x509.SHA256WithRSA
+			gotAlgo := state.PeerCertificates[0].SignatureAlgorithm
+			if wantAlgo != gotAlgo {
+				t.Errorf("expected signature algorithm %v, got %v", wantAlgo, gotAlgo)
+			}
+
 			tlsConn.SetDeadline(time.Now().Add(time.Second))
 			if _, err := io.WriteString(tlsConn, "foo"); err == nil {
 				tlsConn.SetDeadline(time.Now().Add(time.Second))


### PR DESCRIPTION
This makes explicit the default from https://github.com/golang/go/commit/ca3ff9251dbe34edb539b661a30222d0f3d755bd.