### PR TITLE
README: mark repo as decprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+DEPRECATED 
+========== 
+
+This repository is demarcated as deprecated. Please don't use it or any of its
+packages for new projects, and please consider migrating away from it in
+existing projects. Bring questions or concerns to the next internal Go Salon.
+
 go-utils
 ========
 utils for go.


### PR DESCRIPTION
As agreed in yesterday's Go Salon, we're marking this repo as deprecated. I would have provided deeper links to more internal repos and pages, but since this repository is public, I'm erring on the side of caution.