### PR TITLE
move build tags before package declaration

### DIFF
--- a/executable/executable_darwin.go
+++ b/executable/executable_darwin.go
@@ -1,6 +1,6 @@
-package executable
-
 // +build darwin
+
+package executable
 
 // #import <mach-o/dyld.h>
 // #import <libproc.h>

--- a/executable/executable_linux.go
+++ b/executable/executable_linux.go
@@ -1,6 +1,6 @@
-package executable
-
 // +build linux
+
+package executable
 
 import (
 	"fmt"


### PR DESCRIPTION
Something in the Go 1.11 toolchain (automatic "go vet"?) complains
about this.